### PR TITLE
Update Linear Regression.ipynb

### DIFF
--- a/Chapter03/Linear Regression.ipynb
+++ b/Chapter03/Linear Regression.ipynb
@@ -2241,7 +2241,7 @@
     "feature_translator = [(f'x{i}', feature) for i, feature in enumerate(x_train.columns, 0)]\n",
     "\n",
     "def translate_feature_names(s):\n",
-    "    for key, val in feature_translator:\n",
+    "    for key, val in reversed(feature_translator):\n",
     "        s = s.replace(key, val)\n",
     "    return s\n",
     "\n",


### PR DESCRIPTION
Without iterating in reverse, some column names like `x11` and `x12` are erroneously captured by the replacement of `x1` causing a function like:
```python
translate_feature_names('x11 x12')
```
to yield `ZN1 ZN2` rather than `B LSTAT`